### PR TITLE
Update npm publish workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -8,20 +8,24 @@ on:
 jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read # This is required for actions/checkout
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false  # never use caching in release builds
       - run: yarn install
       - run: yarn lint
       - run: "echo 'const credentials = { clientId: \"${{ secrets.RPGLOGS_API_CLIENT_ID }}\", clientSecret: \"${{ secrets.RPGLOGS_API_CLIENT_SECRET }}\" }; export default credentials;' > src/credentials.ts"
       - run: yarn generate
       - run: yarn test
       - run: yarn build-all
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           access: public
 
       - run: yarn docs

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   publish-to-npm:
@@ -27,6 +28,7 @@ jobs:
       - uses: JS-DevTools/npm-publish@v4
         with:
           access: public
+          dry-run: true
 
       - run: yarn docs
         env:


### PR DESCRIPTION
- part of ARC-1190

See the frontend PR for more context regarding the migration https://github.com/RPGLogs/RPGLogsFrontEnd/pull/12676

Bumped the `JS-DevTools/npm-publish` action since `v1` doesn't support OIDC. According to their [migration guide](https://github.com/js-devtools/npm-publish#v1-to-v4), there shouldn't be any breaking changes for how we utilize the action.
Set it up as dry-run for now so we can test it out first