### PR TITLE
remove dry-run from publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v4
         with:
           access: public
-          dry-run: true
 
       - run: yarn docs
         env:


### PR DESCRIPTION
so the action still insists that the version is already published, but it did appear to successfully published, so should be fine :shrug: 

https://github.com/RPGLogs/RPGLogsApiSdk/actions/runs/29824337890/job/88614090888
https://www.npmjs.com/package/@rpglogs/api-sdk?activeTab=readme